### PR TITLE
Update Insight JS SDK version in public template

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -15,13 +15,16 @@
 homepage: "https://www.progress.com/sitefinity-cms/insight"
 documentation: "https://www.progress.com/documentation/sitefinity-cms/insight/upload-data-through-google-tag-manager#:~:text=With%20Sitefinity%20Insight%2C%20you%20can,data%20when%20your%20tags%20fire."
 versions:
-  - sha: 67b559817841f6db4b9c1d5ef5789d24aaeb112a
+  - sha: b3a1380275a0805a663a78fe95b30ff7bf1fd63f
     changeNotes: |2
+      Updated Insight JS SDK version to 3.1.26
+  - sha: 67b559817841f6db4b9c1d5ef5789d24aaeb112a
+    changeNotes:
       Added cross-domain tracking entries control.
       Additional tooltips and labels are also added.
       Tag name change.
   - sha: 16b5e5d31dadaead574f0074e330722c9670299f
-    changeNotes: |2
+    changeNotes:
       Added cross-domain tracking entries control.
       Additional tooltips and labels are also added.
   - sha: 50690b9bb283a9dcc09f8eadc6dc2112117c663f

--- a/template.tpl
+++ b/template.tpl
@@ -283,7 +283,7 @@ const aliasInWindow = require('aliasInWindow');
 const injectScript = require('injectScript');
 const queryPermission = require('queryPermission');
 const productName = 'Sitefinity Insight';
-const sdkUrl = 'https://cdn.insight.sitefinity.com/sdk/sitefinity-insight-client.min.3.1.14.js';
+const sdkUrl = 'https://cdn.insight.sitefinity.com/sdk/sitefinity-insight-client.min.3.1.26.js';
 const bridgeScriptUrl = 'https://cdn.insight.sitefinity.com/sdk/gtm-bridge-latest.min.js';
 
 log('data =', data);


### PR DESCRIPTION
This is the official Insight JS SDK version for the SF 15 release, now updated in the public GTM template as well.